### PR TITLE
modifying wdio script for ts config [Issue:74 fix]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,12 +102,12 @@ async function createWebdriverIO(opts: ProgramOpts) {
         console.log('Adding scripts to package.json')
 
         const pkgJson = require(pkgJsonPath)
-        const isUsingTypescript = await exists('wdio.conf.ts')
+        const isUsingTypescript = await exists('test/wdio.conf.ts')
 
         if (!pkgJson.scripts) {
             pkgJson.scripts = {}
         }
-        pkgJson.scripts['wdio'] = `wdio run wdio.conf.${isUsingTypescript ? 'ts' : 'js'}`
+        pkgJson.scripts['wdio'] = `wdio run ${isUsingTypescript ? 'test/wdio.conf.ts' : 'wdio.conf.js'}`
         await fs.promises.writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 4))
     }
 


### PR DESCRIPTION
I have modified the wdio script which is added to package.json to fix the #74 

1. wdio.conf.js file exist check was modified to test/wdio.conf.ts w.r.t https://github.com/webdriverio/webdriverio/pull/7720
2. wdio script that gets added is modified to ``"wdio": "wdio run test/wdio.conf.ts"``

Signed-off-by: Vignesh Mohanasundaram <vigneshmohan243@yahoo.com>