### PR TITLE
(create-wdio): fix project name on Windows

### DIFF
--- a/__mocks__/commander.ts
+++ b/__mocks__/commander.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import * as path from 'node:path'
 
 const command: any = {}
 command.name = vi.fn().mockReturnValue(command)
@@ -6,7 +7,7 @@ command.version = vi.fn().mockReturnValue(command)
 command.usage = vi.fn().mockReturnValue(command)
 command.arguments = vi.fn().mockReturnValue(command)
 command.action = vi.fn((cb) => {
-    cb('someProjectName')
+    cb(`${path.sep}foo${path.sep}bar${path.sep}someProjectName`)
     return command
 })
 command.option = vi.fn().mockReturnValue(command)

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export async function createWebdriverIO(opts: ProgramOpts) {
     if (!hasPackageJson) {
         await fs.mkdir(root, { recursive: true })
         await fs.writeFile(path.resolve(root, 'package.json'), JSON.stringify({
-            name: root.replace(/\/$/, '').split('/').pop(),
+            name: root.substring(root.lastIndexOf(path.sep) + 1),
             type: 'module'
         }, null, 2))
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -210,6 +210,10 @@ test('does create a package.json to be used by the wdio config command when one 
     expect(runProgram).toBeCalledTimes(2)
     expect(fs.mkdir).toBeCalledTimes(1)
     expect(fs.writeFile).toBeCalledTimes(1)
+    expect(fs.writeFile).toBeCalledWith(
+        expect.any(String),
+        JSON.stringify({ name: 'someProjectName', type: 'module' }, null, 2),
+    )
 })
 
 test('installs the next version when the npmTag option is set to "next"', async () => {


### PR DESCRIPTION
- fixed issue where the package.json name would contain the full path instead of the directory name on Windows